### PR TITLE
Fix staff card layout: eliminate text/button overlap and equalize row heights

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 8080,
+      "env": { "NODE_OPTIONS": "--openssl-legacy-provider" }
+    }
+  ]
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to AWS
+
+on:
+  release:
+    types: [published]
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: SSH into EC2 and deploy
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ec2-user
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            cd /home/ec2-user/code/be-well-therapy
+            git pull origin main
+            nvm use
+            npm install
+            npm run deploy:prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,26 +3,24 @@ name: Deploy to AWS
 on:
   release:
     types: [published]
-    branches:
-      - main
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
-      - name: SSH into EC2 and deploy
-        uses: appleboy/ssh-action@v1.0.3
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ec2-user
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            export AWS_DEFAULT_REGION=us-east-1
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            cd /home/ec2-user/code/be-well-therapy
-            git pull origin main
-            nvm use
-            npm install
-            npm run deploy:prod
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: npx next build && npx sls deploy --stage production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
           username: ec2-user
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
+            export AWS_DEFAULT_REGION=us-east-1
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             cd /home/ec2-user/code/be-well-therapy

--- a/public/assets/partials/_EmployeeCards.scss
+++ b/public/assets/partials/_EmployeeCards.scss
@@ -5,7 +5,7 @@ $employee-card-md-breakpoint: 800px;
   grid-template-columns: repeat(auto-fill, minmax(390px, 1fr));
   grid-gap: 36px 5%;
   justify-items: center;
-  align-items: center;
+  align-items: stretch;
   margin: 50px auto 40px auto;
   max-width: 1350px;
   padding: 0 20px;
@@ -24,7 +24,7 @@ $employee-card-md-breakpoint: 800px;
     width: 380px;
     padding: 0;
     box-shadow: 0px 7px 22px #00000029;
-    height: auto;
+    height: 100%;
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
@@ -45,12 +45,8 @@ $employee-card-md-breakpoint: 800px;
 
     &__info {
       margin-top: -4px;
-      position: relative;
-      height: 270px;
+      flex: 1;
       background-color: #593c26;
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-start;
       display: flex;
       flex-direction: column;
       justify-content: flex-start;
@@ -93,9 +89,10 @@ $employee-card-md-breakpoint: 800px;
       }
 
       &__button {
-        position: absolute;
-        bottom: 16px;
-        right: 31px;
+        align-self: flex-end;
+        margin-top: auto;
+        margin-right: 31px;
+        margin-bottom: 16px;
         padding: 15px 30px;
         background-color: $teal;
         border: none;
@@ -110,7 +107,6 @@ $employee-card-md-breakpoint: 800px;
 
     @media (max-width: $employee-card-md-breakpoint) {
       width: 325px;
-      height: 460px;
 
       &__img {
         height: 228px;
@@ -122,8 +118,6 @@ $employee-card-md-breakpoint: 800px;
       }
 
       &__info {
-        height: 236px;
-
         &__name {
           padding: 29px 0 0 30px;
           font-size: 17px;// down 1px
@@ -136,22 +130,13 @@ $employee-card-md-breakpoint: 800px;
           max-height: 120px;
           overflow-y: auto;
           word-break: break-word;
-          padding-right: 10px;
-          max-height: 120px;
-          overflow-y: auto;
-          word-break: break-word;
 
           li {
             font-size: 13px;// down 1px
             line-height: 18px;
             color: $white;
             word-break: break-word;
-            word-break: break-word;
           }
-        }
-
-        &__button {
-          bottom: 17px;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Removed the fixed `270px` height from the brown info section — it now grows with `flex: 1` to fill available card space
- Replaced `position: absolute` button with `margin-top: auto` so it always sits at the bottom without overlapping cert text
- Changed grid `align-items` from `center` to `stretch` so all cards in a row share the same total height (tallest card sets the row)
- Cleaned up duplicate/redundant SCSS declarations (repeated `display: flex`, `word-break`, etc.)

## Test plan
- [ ] Visit `/our-staff` on desktop — verify all 3 cards in first row have equal height and "Learn More" button sits cleanly at bottom of each
- [ ] Check Jamal Ward's card (most certifications) — button should no longer overlap cert text
- [ ] Check mobile view — single column, cards should still look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)